### PR TITLE
Fix nested "dkan_health_status_api_access" error

### DIFF
--- a/dkan_health_status.module
+++ b/dkan_health_status.module
@@ -60,7 +60,7 @@ function dkan_health_status_api_access() {
   $require_https = variable_get('dkan_health_status_api_require_https', FALSE);
   $https_on = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : ''; 
   $required_key = variable_get('dkan_health_status_health_api_access_key', FALSE);
-  return dkan_health_status_api_access($key, $require_http, $https_on, $required_key);
+  return dkan_health_status_api_access_check($key, $required_key, $require_https, $https_on);
 }
 
 /**


### PR DESCRIPTION
One line change to fix a php fatal error that we experienced on healthdata on the `admin/structure/features` page.
